### PR TITLE
Team a

### DIFF
--- a/include/scenes/Game.h
+++ b/include/scenes/Game.h
@@ -1557,24 +1557,24 @@ class GameScene : public IScene {
                 CreateObjectC(world, position, blockType);
                 break;
             case 60: //右向き
-                lightpos.x += 0.15f;
+                lightpos.x += 0.0f;
                 CreateWallLight(world, position, lightangle, lightpos);
                 CreateWall(world, position);
                 break;
             case 61: //上向き
-                lightpos.z += 0.15f;
+                lightpos.z += 0.0f;
                 lightangle = 270.0f;
                 CreateWallLight(world, position, lightangle, lightpos);
                 CreateWall(world, position);
                 break;
             case 62: //左向き
-                lightpos.x += -0.15f;
+                lightpos.x += 0.0f;
                 lightangle = 180.0f;
                 CreateWallLight(world, position, lightangle, lightpos);
                 CreateWall(world, position);
                 break;
             case 63: //下向き
-                lightpos.z += -0.15f;
+                lightpos.z += 0.0f;
                 lightangle = 90.0f;
                 CreateWallLight(world, position, lightangle, lightpos);
                 CreateWall(world, position);

--- a/include/scenes/StageSelectScene.h
+++ b/include/scenes/StageSelectScene.h
@@ -465,7 +465,7 @@ class StageSelectScene : public IScene {
         GamepadSystem *padsystem = ServiceLocator::TryGet<GamepadSystem>();
         if (!isTransitioning_) {
             if (padsystem &&
-                padsystem->GetAnyButtonDown({GamepadSystem::Button_X})) {
+                padsystem->GetAnyButtonDown({GamepadSystem::Button_A})) {
                 trigger = true;
                 SOUND_SYS.PlaySE(cfg_EnterMP3Pass);
             }
@@ -521,11 +521,14 @@ class StageSelectScene : public IScene {
                 dpadLeftPrev_ = dpadLeftNow;
             }
 
-            /*  if (input.GetKeyDown(VK_F5)) {
+            World *wptr = &world;
+            bool dpadStartNow = padsystem->GetButton(padsystem->Button_B);
+            if (dpadStartNow) {
+                SOUND_SYS.PlaySE(cfg_EnterMP3Pass);
                     if (auto *manager = ServiceLocator::TryGet<SceneManager>()) {
-                        manager->ChangeScene("Title", world);
+                        manager->ChangeScene("Title", *wptr);
                     }
-           }*/
+           }
 
             if (rightPressed) {
                 if (stats.selectStage < maxStage_) {

--- a/include/scenes/Title.h
+++ b/include/scenes/Title.h
@@ -429,7 +429,7 @@ class TitleScene : public IScene {
         
             if (pady > 0.8f && !stickUpPrev_)upPressd = true;
             if (pady < -0.8f && !stickDownPrev_)downPressd = true;
-            if (dpadUp && !dpadDownPrev_)upPressd = true;
+            if (dpadUp && !dpadUpPrev_)upPressd = true;
             if (dpadDown && !dpadDownPrev_)downPressd = true;
 
             stickUpPrev_ = (pady > 0.8f);


### PR DESCRIPTION
セレクト画面でタイトルに戻る処理の追加
蛍光灯の位置調整
タイトルセレクトで上十字キー入力時の高速移動の修正